### PR TITLE
Allow setting default namespace using nicer envvar

### DIFF
--- a/k8sh
+++ b/k8sh
@@ -76,7 +76,7 @@ k8sh_init() {
   fi
   echo "Gathering current kubectl state..."
   export KUBECTL_CONTEXT=$(kubectl config current-context)
-  export KUBECTL_NAMESPACE=${parameter-default}
+  export KUBECTL_NAMESPACE=${DEFAULT_NAMESPACE-default}
 
   echo "Making aliases..."
   alias kubectl="kubectl --context \$KUBECTL_CONTEXT --namespace \$KUBECTL_NAMESPACE"


### PR DESCRIPTION
it seems like the existing variable for the default namespace was copypasted from some documentation like http://www.tldp.org/LDP/abs/html/parameter-substitution.html