### PR TITLE
feat: added istioctl aliase with namespace and context

### DIFF
--- a/examples/k8sh_extensions
+++ b/examples/k8sh_extensions
@@ -15,3 +15,7 @@ busybox() {
   fi
   k run -i --tty busybox --image=busybox --restart=Never --overrides="$OVERRIDE_PARAM" -- sh
 }
+
+# istioctl
+alias istioctl="istioctl --context \$KUBECTL_CONTEXT --namespace \$KUBECTL_NAMESPACE"
+


### PR DESCRIPTION
istioctl tight together with Kubernetes, so might be useful to have it in k8sh

Moved to k8sh_extensions as suggested: https://github.com/Comcast/k8sh/pull/9#issuecomment-532051423