### PR TITLE
Move reloadExtensions call after export PS1

### DIFF
--- a/k8sh
+++ b/k8sh
@@ -156,10 +156,10 @@ k8sh_init() {
       echo -e "${RED}For k completion please install bash-completion${RESTORE}"
   fi
 
-  reloadExtensions
-
   # Set up PS1 prompt
   export PS1="($PS_CONTEXT_COLOR\$KUBECTL_CONTEXT$PS_RESTORE/$PS_NAMESPACE_COLOR\$KUBECTL_NAMESPACE$PS_RESTORE) \W ${PS_LPURPLE}\$${PS_RESTORE} "
+
+  reloadExtensions
 
   echo ""
   echo -e "Context: $CONTEXT_COLOR$KUBECTL_CONTEXT$RESTORE"


### PR DESCRIPTION
This makes altering PS1 from `~/.k8sh_extensions` more convenient.