### PR TITLE
remove cleaning PS1 before init

### DIFF
--- a/k8sh
+++ b/k8sh
@@ -168,5 +168,4 @@ k8sh_init() {
 export -f k8sh_init
 
 echo "Initializing..."
-export PS1="" # Clear PS1 for prettier init
 bash -i <<< 'k8sh_init; exec </dev/tty'


### PR DESCRIPTION
OS: Centos7
pkg: bash-completion-2.1-8.el7.noarch.rpm

/etc/profile.d/bash_completion.sh

```
# Check for interactive bash and that we haven't already been sourced.
[ -z "$BASH_VERSION" -o -z "$PS1" -o -n "$BASH_COMPLETION_COMPAT_DIR" ] && return
```

so, when PS1="" - no source /usr/share/bash-completion/bash_completion
and type -t _get_comp_words_by_ref return empty string
autocomplete not working